### PR TITLE
Support Immutable values

### DIFF
--- a/chrome/extension/page-api.js
+++ b/chrome/extension/page-api.js
@@ -1,6 +1,7 @@
 function evalPromise(str) {
   return new Promise((resolve, reject) => {
-    chrome.devtools.inspectedWindow.eval(str, (result, err) => {
+    chrome.devtools.inspectedWindow.eval(str, (resultStr, err) => {
+      const result = JSON.parse(resultStr);
       if (err && err.isException) {
         console.error(err.value);
         reject(err.value);
@@ -15,12 +16,12 @@ export function checkSelector(id) {
   const str = `(function() {
     const __reselect_last_check = window.__RESELECT_TOOLS__.checkSelector('${id}');
     console.log(__reselect_last_check);
-    return __reselect_last_check;
+    return JSON.stringify(__reselect_last_check);
   })()`;
   return evalPromise(str);
 }
 
 export function selectorGraph() {
-  const str = 'window.__RESELECT_TOOLS__.selectorGraph()';
+  const str = 'JSON.stringify(window.__RESELECT_TOOLS__.selectorGraph())';
   return evalPromise(str);
 }


### PR DESCRIPTION
Fixes #3

`chrome.devtools.inspectedWindow.eval` "sanitises" objects so that Immutable objects become bare copies of the internal state.
Converting to JSON gives a "prettier" object model.